### PR TITLE
Configurable Service TimeOut + PublishAll Retry + Improved XML Documentation

### DIFF
--- a/src/Delegate.Daxif/API/Data.fs
+++ b/src/Delegate.Daxif/API/Data.fs
@@ -9,6 +9,8 @@ type Data private () =
 
   /// <summary>Counts the amount of records for the given entity logical names.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="entityNames">List of entity logical names to include in record count.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Count(env: Environment, entityNames, ?logLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel
@@ -17,6 +19,14 @@ type Data private () =
 
   /// <summary>Imports data from a given file.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="pathToData">A relative or absolute path to a data import file.</param>
+  /// <param name="serialize">Serialization format ('BIN', 'XML' or 'JSON') - defaults to: 'JSON'</param>
+  /// <param name="guidRemapping">Guid remapping map</param>
+  /// <param name="additionalAttributes">Additional attributes to include in data import</param>
+  /// <param name="includeAttributes">Flag whether or not to include attributes in data import - defaults to: true</param>
+  /// <param name="includeReferences">Flag whether or not to include references (lookup attributes) in data import - defaults to: true</param>
+  /// <param name="referenceFilter">List of filtering which lookup attributes to include in data import (based on logical name)</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Import(env: Environment, pathToData, ?serialize, ?guidRemapping, ?additionalAttributes, ?includeAttributes, ?includeReferences, ?referenceFilter, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     
@@ -32,6 +42,10 @@ type Data private () =
 
   /// <summary>Exports data from given entities to a file.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="entityNames">List of entity logical names to include in data export.</param>
+  /// <param name="pathToOutputFile">A relative or absolute path to a data export output file.</param>
+  /// <param name="deltaFromDate">Export only entities with modified on or later than date given as DateTime.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Export(env: Environment, entityNames, pathToOutputFile, ?deltaFromDate, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
 

--- a/src/Delegate.Daxif/API/ExtendedSolution.fs
+++ b/src/Delegate.Daxif/API/ExtendedSolution.fs
@@ -8,19 +8,32 @@ type ExtendedSolution private () =
 
   /// <summary>Extends an exported solution package from a given environment. Run this after solution export</summary>
   /// <param name="env">Environment the action should be performed against.</param>
-  static member Export(env: Environment, pathToSolutionZip, ?logLevel) =
+  /// <param name="pathToSolutionZip">A relative or absolute path to solution file.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
+  /// <param name="timeOut">DataVerse Service Client timeout represented as a TimeSpan. - defaults to: 1 hour</param>
+  static member Export(env: Environment, pathToSolutionZip, ?logLevel, ?timeOut: System.TimeSpan) =
+    let timeOut = timeOut ?| defaultServiceTimeOut
     log.setLevelOption logLevel
-    Main.extendSolution env pathToSolutionZip
+    Main.extendSolution env pathToSolutionZip timeOut
 
   /// <summary>Starts pre-import task for an extended solution. Run this before solution import</summary>
   /// <param name="env">Environment the action should be performed against.</param>
-  static member PreImport(env: Environment, pathToSolutionZip, ?logLevel) =
+  /// <param name="pathToSolutionZip">A relative or absolute path to solution file.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
+  /// <param name="timeOut">DataVerse Service Client timeout represented as a TimeSpan. - defaults to: 1 hour</param>
+  static member PreImport(env: Environment, pathToSolutionZip, ?logLevel, ?timeOut: System.TimeSpan) =
+    let timeOut = timeOut ?| defaultServiceTimeOut
     log.setLevelOption logLevel
-    Main.preImportExtendedSolution env pathToSolutionZip
+    Main.preImportExtendedSolution env pathToSolutionZip timeOut
 
   /// <summary>Starts post-import task for an extended solution. Run this after solution import</summary>
   /// <param name="env">Environment the action should be performed against.</param>
-  static member PostImport(env: Environment, pathToSolutionZip, ?reassignWorkflows, ?logLevel) =
+  /// <param name="pathToSolutionZip">A relative or absolute path to solution file.</param>
+  /// <param name="reassignWorkflows">Flag whether to reassign workflows based on environment from which the solution was exported. - defaults to: false</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
+  /// <param name="timeOut">DataVerse Service Client timeout represented as a TimeSpan. - defaults to: 1 hour</param>
+  static member PostImport(env: Environment, pathToSolutionZip, ?reassignWorkflows, ?logLevel, ?timeOut: System.TimeSpan) =
+    let timeOut = timeOut ?| defaultServiceTimeOut
     log.setLevelOption logLevel
     let reassignWorkflows = reassignWorkflows ?| false
-    Main.postImportExtendedSolution env pathToSolutionZip reassignWorkflows
+    Main.postImportExtendedSolution env pathToSolutionZip reassignWorkflows timeOut

--- a/src/Delegate.Daxif/API/Info.fs
+++ b/src/Delegate.Daxif/API/Info.fs
@@ -9,6 +9,7 @@ type Info private () =
 
   /// <summary>Retrieves the CRM version of the targeted environment.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member RetrieveVersion(env: Environment, ?logLevel: LogLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel

--- a/src/Delegate.Daxif/API/Plugin.fs
+++ b/src/Delegate.Daxif/API/Plugin.fs
@@ -9,6 +9,13 @@ type Plugin private () =
 
   /// <summary>Updates plugin registrations in CRM based on the plugins found in your local assembly.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="assemblyPath">Path to the plugin assembly dll to be synced (usually under the project bin folder).</param>
+  /// <param name="projectPath">Path to the plugin assembly project (.csproj).</param>
+  /// <param name="solutionName">The name of the solution to which to sync plugins</param>
+  /// <param name="dryRun">Flag whether or not to simulate/test syncing plugins (running a 'dry run'). - defaults to: false</param>
+  /// <param name="isolationMode">Assembly Isolation Mode ('Sandbox' or 'None'). All Online environments must use 'Sandbox' - defaults to: 'Sandbox'</param>
+  /// <param name="ignoreOutdatedAssembly">Flag whether or not to simulate/test syncing plugins (running a 'dry run'). - defaults to: false</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Sync(env: Environment, assemblyPath: string, projectPath: string, solutionName: string, ?dryRun: bool, ?isolationMode: AssemblyIsolationMode, ?ignoreOutdatedAssembly: bool, ?logLevel: LogLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel
@@ -21,5 +28,8 @@ type Plugin private () =
 
   /// <summary>Activates or deactivates all plugin steps of a solution</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="solutionName">The name of the solution in which to enable or disable all plugins</param>
+  /// <param name="enable">Flag whether to enable or disable all solution plugins. - defaults to: true</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member EnableSolutionPluginSteps(env: Environment, solutionName, ?enable, ?logLevel) =
     SolutionMain.enablePluginSteps env solutionName enable logLevel

--- a/src/Delegate.Daxif/API/Solution.fs
+++ b/src/Delegate.Daxif/API/Solution.fs
@@ -17,33 +17,67 @@ type Solution private () =
 
   /// <summary>Publish all customization. Not necessary after a import of an managed solution</summary>
   /// <param name="env">Environment the action should be performed against.</param>
-  static member PublishAll(env: Environment, ?logLevel) =
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug</param>
+  /// <param name="timeOut">DataVerse Service Client timeout represented as a TimeSpan. - defaults to: 15 minutes</param>
+  /// <remarks>Due to Microsoft's PublishAll API Message often timing out first time after a Solution Import (although publish went through server-side), this function will retry once after timeout failure.</remarks>
+  static member PublishAll(env: Environment, ?logLevel, ?timeOut: System.TimeSpan) =
+    let timeOut = timeOut ?| System.TimeSpan(0,15,0)
+
     log.setLevelOption logLevel
-    Main.PublishAll env
+    try
+        Main.PublishAll env timeOut
+    with
+        | :? System.TimeoutException as ex -> 
+            log.Warn "PublishAll timed out with message: %s" ex.Message
+            log.Warn "Trying again..."
+            Main.PublishAll env timeOut
 
   /// <summary>Imports a solution package from a given environment</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="pathToSolutionZip">A relative or absolute path to solution file.</param>
+  /// <param name="activatePluginSteps">Flag whether or not to enable all solution plugins. - defaults to: false</param>
+  /// <param name="extended">Flag whether or not to enable Delegate Extended Solution functionality. - defaults to: false</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   /// <param name="diffCallingInfo">[Experimental] When specified, a diff import will be performed. Assumes exportdiff has been used prior.</param>
-  static member Import(env: Environment, pathToSolutionZip, ?activatePluginSteps, ?extended, ?logLevel, ?diffCallingInfo, ?publishAfterImport, ?reassignWorkflows) =    
+  /// <param name="publishAfterImport">Flag whether or not to publish all customizations after solution import. - defaults to: true</param>
+  /// <param name="reassignWorkflows">Flag whether to reassign workflows based on environment from which the solution was exported. - defaults to: false</param>
+  /// <param name="timeOut">DataVerse Service Client timeout represented as a TimeSpan. - defaults to: 1 hour</param>
+  static member Import(env: Environment, pathToSolutionZip, ?activatePluginSteps, ?extended, ?logLevel, ?diffCallingInfo, ?publishAfterImport, ?reassignWorkflows, ?timeOut: System.TimeSpan) =    
     let publishAfterImport = publishAfterImport ?| true
     let reassignWorkflows = reassignWorkflows ?| false
+    let timeOut = timeOut ?| defaultServiceTimeOut
+
     match diffCallingInfo with
-    | Some dci -> Main.importDiff pathToSolutionZip dci.SolutionName Domain.partialSolutionName env
-    | _ -> Main.importStandard env activatePluginSteps extended publishAfterImport reassignWorkflows pathToSolutionZip logLevel
+    | Some dci -> Main.importDiff pathToSolutionZip dci.SolutionName Domain.partialSolutionName env timeOut
+    | _ -> Main.importStandard env activatePluginSteps extended publishAfterImport reassignWorkflows pathToSolutionZip logLevel timeOut
 
   /// <summary>Exports a solution package from a given environment</summary>
   /// <param name="env">Environment the action should be performed against.</param>
-  /// <param name="async"> Execute solution export asynchronously</param
-  /// <param name="diffCallingInfo">[Experimental] When specified, a diff export happens with env as source and diffCallingInfo.TargetEnv as target</param
-  static member Export(env: Environment, solutionName, outputDirectory, managed, ?extended, ?deltaFromDate, ?logLevel, ?diffCallingInfo, ?async) =
+  /// <param name="solutionName">The name of the solution to export.</param>
+  /// <param name="outputDirectory">The directory to which the solution file will be saved.</param>
+  /// <param name="managed">Flag whether to export as Managed or Unmanaged solution.</param>
+  /// <param name="extended">Flag whether or not to enable Delegate Extended Solution functionality. - defaults to: false</param>
+  /// <param name="deltaFromDate">N/A - Not used</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
+  /// <param name="diffCallingInfo">[Experimental] When specified, a diff export happens with env as source and diffCallingInfo.TargetEnv as target</param>
+  /// <param name="async">Flag whether to execute solution export asynchronously. - defaults to: false</param>
+  /// <param name="timeOut">DataVerse Service Client timeout represented as a TimeSpan. - defaults to: 1 hour</param>
+  static member Export(env: Environment, solutionName, outputDirectory, managed, ?extended, ?deltaFromDate, ?logLevel, ?diffCallingInfo, ?async, ?timeOut: System.TimeSpan) =
     let async = async ?| false
+    let timeOut = timeOut ?| defaultServiceTimeOut
 
     match diffCallingInfo with
-    | Some dci -> Main.exportDiff outputDirectory solutionName Domain.partialSolutionName async env dci.TargetEnv
-    | _ -> Main.exportStandard env solutionName outputDirectory managed extended async
+    | Some dci -> Main.exportDiff outputDirectory solutionName Domain.partialSolutionName async env dci.TargetEnv timeOut
+    | _ -> Main.exportStandard env solutionName outputDirectory managed extended async timeOut
     
-  /// <summary>Generates TypeScript context from a given environment and settings using XrmDefinitelyTyped</summary>
+  /// <summary>Generates TypeScript context from a given environment and settings using XrmDefinitelyTyped (XDT)</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="pathToXDT">A relative or absolute path to XrmDefinitelyTyped (XDT) executable.</param>
+  /// <param name="outputDir">The directory under which the TypeScript Context will be saved.</param>
+  /// <param name="solutions">List of solutions to include in TypeScript Context.</param>
+  /// <param name="entities">List of entities to include in TypeScript Context.</param>
+  /// <param name="extraArguments">Extra command-line arguments to pass to XrmDefinitelyTyped (XDT) executable.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member GenerateTypeScriptContext(env: Environment, pathToXDT, outputDir, ?solutions, ?entities, ?extraArguments, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     
@@ -55,6 +89,12 @@ type Solution private () =
     
   /// <summary>Generates C# context from a given environment and settings using XrmContext</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="pathToXrmContext">A relative or absolute path to XrmContext executable.</param>
+  /// <param name="outputDir">The directory under which the C# Context will be saved.</param>
+  /// <param name="solutions">List of solutions to include in C# Context.</param>
+  /// <param name="entities">List of entities to include in C# Context.</param>
+  /// <param name="extraArguments">Extra command-line arguments to pass to XrmContext executable.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member GenerateCSharpContext(env: Environment, pathToXrmContext, outputDir, ?solutions, ?entities, ?extraArguments, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     
@@ -66,6 +106,12 @@ type Solution private () =
 
   /// <summary>Generates XrmMockup Metadata from a given environment and settings using XrmMockup's MetadataGenerator</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="pathToXrmMockupGenerator">A relative or absolute path to XrmMockup executable.</param>
+  /// <param name="outputDir">The directory under which the XrmMockup Metadata will be saved.</param>
+  /// <param name="solutions">List of solutions to include in XrmMockup Metadata.</param>
+  /// <param name="entities">List of entities to include in XrmMockup Metadata.</param>
+  /// <param name="extraArguments">Extra command-line arguments to pass to XrmMockup executable.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member GenerateXrmMockupMetadata(env: Environment, pathToXrmMockupGenerator, outputDir, ?solutions, ?entities, ?extraArguments, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     
@@ -78,6 +124,8 @@ type Solution private () =
 
   /// <summary>Counts the amount of entities in a solution</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="solutionName">The name of the solution for which to count entities.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Count(env: Environment, solutionName, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     Main.count env solutionName logLevel
@@ -85,20 +133,31 @@ type Solution private () =
 
   /// <summary>Activates or deactivates all plugin steps of a solution</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="solutionName">The name of the solution in which to enable or disable all plugins</param>
+  /// <param name="enable">Flag whether to enable or disable all solution plugins. - defaults to: true</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member EnablePluginSteps(env: Environment, solutionName, ?enable, ?logLevel) =
     Main.enablePluginSteps env solutionName enable logLevel
 
 
   /// <summary>Creates a solution in the given environment</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="name">Desired Solution Name</param>
+  /// <param name="displayName">Desired Solution Display Name</param>
+  /// <param name="publisherPrefix">Desired Publisher Prefix (must be an existing publisher in the environment)</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Create(env: Environment, name, displayName, publisherPrefix, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     
     Main.create env name displayName publisherPrefix logLevel
 
 
-  /// <summary>Creates a publish in the given environment</summary>
+  /// <summary>Creates a publisher in the given environment</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="name">Desired Publisher Name</param>
+  /// <param name="displayName">Desired Publisher Display Name</param>
+  /// <param name="prefix">Desired Publisher Prefix</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member CreatePublisher(env: Environment, name, displayName, prefix, ?logLevel) =
     let logLevel = logLevel ?| LogLevel.Verbose
     

--- a/src/Delegate.Daxif/API/Translations.fs
+++ b/src/Delegate.Daxif/API/Translations.fs
@@ -9,6 +9,9 @@ type Translations private () =
 
   /// <summary>Exports translations from a given solution to a given directory.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="solutionName">The name of the solution from which to export translations.</param>
+  /// <param name="outputDir">The directory into which the translation file will be saved (SolutionName + '_Translations.xip').</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Export(env: Environment, solutionName, outputDir, ?logLevel: LogLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel
@@ -16,6 +19,9 @@ type Translations private () =
 
   /// <summary>Imports translations to a given solution from a given directory.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="solutionName">The name of the solution to which to import translations.</param>
+  /// <param name="outputDir">The directory from which the translation file will be loaded.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Import(env: Environment, solutionName, outputDir, ?logLevel: LogLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel

--- a/src/Delegate.Daxif/API/View.fs
+++ b/src/Delegate.Daxif/API/View.fs
@@ -11,6 +11,10 @@ type View private () =
 
   /// <summary>Generates the files needed for View Extender</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="daxifRoot">Daxif script folder.</param>
+  /// <param name="entities">List of entities to include in View Extender files.</param>
+  /// <param name="solutions">List of solutions to include in View Extender files.</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member GenerateFiles(env: Environment, daxifRoot: string, ?entities: string[], ?solutions: string[], ?logLevel: LogLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel

--- a/src/Delegate.Daxif/API/WebResource.fs
+++ b/src/Delegate.Daxif/API/WebResource.fs
@@ -10,6 +10,10 @@ type WebResource private () =
 
   /// <summary>Updates the web resources in CRM based on the ones from your local web resource root.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="webresourceRoot">Root folder of the Web Resources project.</param>
+  /// <param name="solutionName">The name of the solution to which to sync web resources</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
+  /// <param name="patchSolutionName">The name of the patch solution to which to sync web resources.</param>
   static member Sync(env: Environment, webresourceRoot: string, solutionName: string, ?logLevel: LogLevel, ?patchSolutionName: string) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel

--- a/src/Delegate.Daxif/API/Workflow.fs
+++ b/src/Delegate.Daxif/API/Workflow.fs
@@ -10,6 +10,10 @@ type Workflow private () =
 
   /// <summary>Synchronizes all CodeActivities found in your local assembly to CRM.</summary>
   /// <param name="env">Environment the action should be performed against.</param>
+  /// <param name="assemblyPath">Path to the workflow activity assembly dll to be synced (usually under the project bin folder).</param>
+  /// <param name="solutionName">The name of the solution to which to sync workflow activities</param>
+  /// <param name="isolationMode">Assembly Isolation Mode ('Sandbox' or 'None'). All Online environments must use 'Sandbox' - defaults to: 'Sandbox'</param>
+  /// <param name="logLevel">Log Level - Error, Warning, Info, Verbose or Debug - defaults to: 'Verbose'</param>
   static member Sync(env: Environment, assemblyPath: string, solutionName: string, ?isolationMode: AssemblyIsolationMode, ?logLevel: LogLevel) =
     let proxyGen = env.connect(log).GetService
     log.setLevelOption logLevel

--- a/src/Delegate.Daxif/Common/InternalUtility.fs
+++ b/src/Delegate.Daxif/Common/InternalUtility.fs
@@ -120,3 +120,5 @@ let syncDescription () =
 
 let logVersion (log: ConsoleLogger) =
   log.Info "%s" daxifVersion
+
+let defaultServiceTimeOut = TimeSpan(0,59,0)

--- a/src/Delegate.Daxif/Modules/Solution/DiffFetcher.fs
+++ b/src/Delegate.Daxif/Modules/Solution/DiffFetcher.fs
@@ -21,9 +21,9 @@ let fetchSolution proxy (solution: string) =
   let columnSet = ColumnSet("uniquename", "friendlyname", "publisherid", "version")
   CrmDataInternal.Entities.retrieveSolution proxy solution columnSet
 
-let downloadSolution (env: DG.Daxif.Environment) file_location sol_name async =
+let downloadSolution (env: DG.Daxif.Environment) file_location sol_name async (timeOut: TimeSpan) =
   log.Verbose "Exporting extended solution %A" (file_location + sol_name)
-  SolutionHelper.exportWithExtendedSolution env sol_name file_location false async
+  SolutionHelper.exportWithExtendedSolution env sol_name file_location false async timeOut
 
 let unzip file =
   log.Verbose "Unpacking zip '%s' to '%s'" (file + ".zip") file;

--- a/src/Delegate.Daxif/Modules/Solution/SolutionHelper.fs
+++ b/src/Delegate.Daxif/Modules/Solution/SolutionHelper.fs
@@ -212,8 +212,8 @@ let workflow' (env: Environment) solutionname enable (log : ConsoleLogger) =
         + solutionId.ToString() + @")"
       log.WriteLine(LogLevel.Verbose, msg)
 
-let exportWithExtendedSolution (env: Environment) solution location managed async = 
-  let service = env.connect().GetService()
+let exportWithExtendedSolution (env: Environment) solution location managed async (timeOut: TimeSpan) = 
+  let service = env.connect().GetService(timeOut)
   let solutionPath =
     match async with
     | false -> Export.exportSync service solution location managed
@@ -221,8 +221,8 @@ let exportWithExtendedSolution (env: Environment) solution location managed asyn
   Extend.export service solution solutionPath
   solutionPath
 
-let importWithExtendedSolution reassignWorkflows (env: Environment) solution location managed = 
-  let service = env.connect().GetService()
+let importWithExtendedSolution reassignWorkflows (env: Environment) solution location managed (timeOut: TimeSpan) = 
+  let service = env.connect().GetService(timeOut)
   Extend.preImport service solution location
   Import.execute service solution location managed
   |> fun jobInfo -> jobInfo.result

--- a/src/Delegate.Daxif/Setup/EnvironmentSetup.fs
+++ b/src/Delegate.Daxif/Setup/EnvironmentSetup.fs
@@ -106,36 +106,39 @@ type Connection = {
       | Some cs -> { method = ConnectionMethod.ConnectionString cs }
 
   /// Connects to the environment and returns IOrganizationService
-  member x.GetService() =
+  member x.GetService(?timeOut: TimeSpan) =
+    let timeOut = defaultArg timeOut defaultServiceTimeOut
     match x.method with
     | ConnectionMethod.Proxy _ -> 
       x.GetProxy() :> IOrganizationService
     | ConnectionMethod.CrmServiceClientOAuth _
     | ConnectionMethod.CrmServiceClientClientSecret _
     | ConnectionMethod.ConnectionString _ -> 
-      x.GetCrmServiceClient() :> IOrganizationService
+      x.GetCrmServiceClient(timeOut) :> IOrganizationService
 
   /// Connects to the environment and returns an OrganizationServiceProxy
-  member x.GetProxy() = 
+  member x.GetProxy(?timeOut: TimeSpan) = 
+    let timeOut = defaultArg timeOut defaultServiceTimeOut
     match x.method with
     | ConnectionMethod.Proxy proxy -> 
-      CrmAuth.getOrganizationServiceProxy proxy.serviceManager proxy.credentials
+      CrmAuth.getOrganizationServiceProxy proxy.serviceManager proxy.credentials timeOut
     | ConnectionMethod.CrmServiceClientOAuth _
     | ConnectionMethod.CrmServiceClientClientSecret _
     | ConnectionMethod.ConnectionString _ ->
       failwith "Not possible to get an OrganizationProxy usign OAuth or Client Secret. Get a CrmServiceClient instead"
 
   /// Connects to the environment and returns a CrmServiceClient
-  member x.GetCrmServiceClient() =
+  member x.GetCrmServiceClient(?timeOut: TimeSpan) =
+    let timeOut = defaultArg timeOut defaultServiceTimeOut
     match x.method with
     | ConnectionMethod.Proxy _ -> 
       failwith "Unable to get CrmServiceClient with Proxy method"
     | ConnectionMethod.CrmServiceClientOAuth oauth ->
-      CrmAuth.getCrmServiceClient oauth.username oauth.password oauth.orgUrl oauth.clientId oauth.returnUrl
+      CrmAuth.getCrmServiceClient oauth.username oauth.password oauth.orgUrl oauth.clientId oauth.returnUrl timeOut
     | ConnectionMethod.CrmServiceClientClientSecret clientSecret ->
-      CrmAuth.getCrmServiceClientClientSecret clientSecret.orgUrl clientSecret.clientId clientSecret.clientSecret
+      CrmAuth.getCrmServiceClientClientSecret clientSecret.orgUrl clientSecret.clientId clientSecret.clientSecret timeOut
     | ConnectionMethod.ConnectionString cs ->
-      CrmAuth.getCrmServiceClientConnectionString cs
+      CrmAuth.getCrmServiceClientConnectionString cs timeOut
 
 /// Describes a connection to a Dynamics 365/CRM environment
 and Environment = {


### PR DESCRIPTION
- PublishAll API function now retries a 2nd time if 1st first returned a timeout
- Configurable Service Timeout on several API functions
- Global 'defaultServiceTimeOut' variable with existing timeout of 59 minutes
- PublishAll service timeout defaults to 15 minutes (have yet to see a succeeding call taking longer than 10 minutes ;-))
- Updated XML Documentation for API functions (eliminated compile warnings)

List of API functions affected:

- SolutionSolution.PreImport
- Solution.Import
- Solution.Publish
- Solution.PostImport
- ExtendedSolution.PreImport
- ExtendedSolution.Import
- ExtendedSolution.PostImport