### PR TITLE
Support for .resx files.

### DIFF
--- a/src/Delegate.Daxif/Daxif.fs
+++ b/src/Delegate.Daxif/Daxif.fs
@@ -13,7 +13,7 @@ type SerializeType =
   | XML of string
   | JSON of string
 
-/// Matches CRM2011/2013 OptionSet values
+/// Matches D365 OptionSet values
 type WebResourceType = 
   | HTML =  1
   | HTM  =  1
@@ -30,7 +30,8 @@ type WebResourceType =
   | XSL  =  9
   | XSLT =  9
   | ICO  = 10
-  | SVG  = 11 // Added in 9.0, enum number unconfirmed
+  | SVG  = 11 // D365 only
+  | RESX = 12 // D365 only
 
 /// CRM Releases
 /// Newer versions have higher values

--- a/src/Delegate.Daxif/Modules/WebResources/WebResourcesHelper.fs
+++ b/src/Delegate.Daxif/Modules/WebResources/WebResourcesHelper.fs
@@ -43,7 +43,7 @@ let getLocalResourcesHelper location crmRelease =
       Enum.GetNames(typeof<DG.Daxif.WebResourceType>)
       |> Array.map (fun x -> @"." + x.ToLower())
       |> Array.toList
-      |> List.filter (fun x -> x <> ".svg" || crmRelease >= CrmReleases.D365)
+      |> List.filter (fun x -> (x <> ".svg" && x <> ".resx" ) || crmRelease >= CrmReleases.D365)
       
     let rec getLocalResources' exts' = 
       seq { 


### PR DESCRIPTION
Change is not backwards compatible on projects that have `.resx` files in their web resource folder or in their CRM solution.
Fixes #58