### PR TITLE
Changed plugin registration to create a new assembly, if major/minor version was bumped

### DIFF
--- a/src/Delegate.Daxif/Modules/Plugins/Compare.fs
+++ b/src/Delegate.Daxif/Modules/Plugins/Compare.fs
@@ -138,20 +138,21 @@ let image (img: Image) (x: Entity) =
 
 /// Compares an assembly from CRM with the one containing the source code
 /// Returns true if the assembly in CRM is newer and the hash matches the one in the source code
-let registeredIsSameAsLocal (local: AssemlyLocal) (registered: AssemblyRegistration option) =
-  registered
-  ?|> fun y -> 
-        let log = ConsoleLogger.Global
+let registeredIsSameAsLocal (local: AssemlyLocal) (registered: AssemblyRegistration) =
+  let log = ConsoleLogger.Global
 
-        let environmentIsNewer = y.version .>= local.version
-        log.Verbose "Registered version %s is %s than local version %s"
-            (y.version |> versionToString) (if environmentIsNewer then "newer" else "older") (local.version |> versionToString)
+  let environmentIsNewer = registered.version .>= local.version
+  log.Verbose "Registered version %s is %s than local version %s"
+      (registered.version |> versionToString) (if environmentIsNewer then "newer" else "older") (local.version |> versionToString)
         
-        let hashMatch = y.hash = local.hash
-        log.Verbose "Registered assembly hash %s local assembly hash" (if hashMatch then "matches" else "does not match")
+  let hashMatch = registered.hash = local.hash
+  log.Verbose "Registered assembly hash %s local assembly hash" (if hashMatch then "matches" else "does not match")
 
-        let isSameAssembly = environmentIsNewer && hashMatch
-        log.Verbose "Assembly will%s be updated" (if isSameAssembly then " not" else "")
-        
-        isSameAssembly
-  ?| false
+  let isSameAssembly = environmentIsNewer && hashMatch
+  log.Verbose "Assembly will%s be updated" (if isSameAssembly then " not" else "")
+  
+  let majorMinorUpdate = 
+    (local.version, registered.version) 
+    |> fun ((a1, b1, _, _), (a2, b2, _, _)) -> a1 > a2 || (a1 = a2 && b1 > b2)
+
+  isSameAssembly, majorMinorUpdate

--- a/src/Delegate.Daxif/Modules/Plugins/MainHelper.fs
+++ b/src/Delegate.Daxif/Modules/Plugins/MainHelper.fs
@@ -65,8 +65,11 @@ let localToMaps (plugins: Plugin seq) (customAPIs: CustomAPI seq) =
 /// Determine which operation we want to perform on the assembly
 let determineOperation (asmReg: AssemblyRegistration option) (asmLocal) : AssemblyOperation * Guid =
   match asmReg with
-  | Some asm when Compare.registeredIsSameAsLocal asmLocal (Some asm) -> Unchanged, asm.id
-  | Some asm -> Update, asm.id
+  | Some asm -> 
+    match Compare.registeredIsSameAsLocal asmLocal asm with 
+    | true, _      -> Unchanged, asm.id
+    | false, false -> Update, asm.id
+    | false, true  -> Create, Guid.Empty
   | None     -> Create, Guid.Empty
 
 /// Update or create assembly


### PR DESCRIPTION
Change made to handle importing of managed solutions where plugin classes have been deleted.
[Microsoft Docs: Update plugin assembly](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/register-plug-in#update-an-assembly).

Unfinished:
- Testing that this doesn't break anything else
- Deletion of old version of the assembly